### PR TITLE
build(deps): bump qs from 6.14.1 to 6.15.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ catalogs:
       specifier: ^8.0.0
       version: 8.0.0
     qs:
-      specifier: ^6.14.0
-      version: 6.14.1
+      specifier: ^6.14.2
+      version: 6.15.1
     query-string:
       specifier: ^9.3.1
       version: 9.3.1
@@ -284,7 +284,7 @@ importers:
         version: 1.13.4
       qs:
         specifier: 'catalog:'
-        version: 6.14.1
+        version: 6.15.1
       query-string:
         specifier: 'catalog:'
         version: 9.3.1
@@ -4641,8 +4641,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -10924,7 +10924,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.1:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
   object-inspect: ^1.13.4
   oxfmt: ^0.27.0
   pkg-dir: ^8.0.0
-  qs: ^6.14.0
+  qs: ^6.14.2
   query-string: ^9.3.1
   react: ^19.0.0
   react-dom: ^19.0.0


### PR DESCRIPTION
## Summary

- Raise `qs` catalog floor from `^6.14.0` to `^6.14.2` (resolves to 6.15.1)
- Patch-level changes only: `arrayLimit` parse bug fixes
- Replaces #23 (closed due to merge conflicts after #24)

## Test plan

- [x] `pnpm run checkTypes` passes
- [x] `pnpm test` — 205 tests pass
- [x] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)