### PR TITLE
fix(docs): add Vite alias to resolve lib from source

### DIFF
--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -1,8 +1,21 @@
+import { resolve } from "node:path";
 import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
+const qs = resolve(import.meta.dirname, "../nanostores-qs/src");
+
 export default defineConfig({
+  vite: {
+    resolve: {
+      // Resolve to source .ts files so docs dev/build doesn't depend on lib dist.
+      // Order matters: subpath regex must precede bare import (prefix match).
+      alias: [
+        { find: /^@vp-tw\/nanostores-qs\/(.+)$/, replacement: resolve(qs, "$1.ts") },
+        { find: "@vp-tw/nanostores-qs", replacement: resolve(qs, "main.ts") },
+      ],
+    },
+  },
   site: "https://vdustr.github.io",
   // base is NOT set here — passed via CLI for production builds:
   //   astro build --base=/nanostores-qs/


### PR DESCRIPTION
## Summary

- Add Vite resolve alias in `astro.config.ts` so docs imports resolve directly to lib source `.ts` files
- Fixes `No matching export in "../nanostores-qs/dist/presets.js" for import "createPreset"` when dist is stale
- Docs dev/build no longer depends on `pnpm build:lib` as a prerequisite

## Test plan

- [x] `pnpm --filter docs build` succeeds without prior lib build
- [x] `pnpm run checkTypes` passes
- [x] `pnpm test` — 205 tests pass
- [x] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)