### PR TITLE
fix(docs): use env var for base path — fixes broken gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: pnpm --filter @vp-tw/nanostores-qs build
-      - run: pnpm --filter docs build -- --base=/${{ github.event.repository.name }}/
+      - run: pnpm --filter docs build
+        env:
+          DOCS_BASE: /${{ github.event.repository.name }}/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: packages/docs/dist

--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import process from "node:process";
 import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
@@ -17,9 +18,8 @@ export default defineConfig({
     },
   },
   site: "https://vdustr.github.io",
-  // base is NOT set here — passed via CLI for production builds:
-  //   astro build --base=/nanostores-qs/
-  // In dev mode, no base prefix → http://localhost:4321/
+  // In CI, DOCS_BASE is set to "/<repo-name>/". In dev, omitted → no prefix.
+  base: process.env.DOCS_BASE,
   integrations: [
     starlight({
       title: "@vp-tw/nanostores-qs",


### PR DESCRIPTION
## Summary

- pnpm escapes `=` in `-- --base=/path/` args, so Astro never received the base path
- All deployed assets at https://vp-tw.github.io/nanostores-qs/ load from `/` instead of `/nanostores-qs/` — CSS, JS, images all 404
- Switch to `DOCS_BASE` env var in `astro.config.ts` + `gh-pages.yml`

## Test plan

- [x] `pnpm --filter docs build` — no base (dev mode) works
- [x] `DOCS_BASE=/nanostores-qs/ pnpm --filter docs build` — assets get `/nanostores-qs/` prefix
- [x] `pnpm run checkTypes` passes
- [x] `pnpm test` — 205 tests pass
- [x] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)