### PR TITLE
build(deps): bump astro from 5.17.1 to 5.18.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ catalogs:
       specifier: ^4.0.0
       version: 4.0.0
     astro:
-      specifier: ^5.17.1
-      version: 5.17.1
+      specifier: ^5.18.1
+      version: 5.18.1
     commitizen:
       specifier: ^4.3.1
       version: 4.3.1
@@ -242,7 +242,7 @@ importers:
         version: 4.4.2(@types/node@22.13.10)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(jiti@2.4.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tsx@4.19.3)(yaml@2.8.2)
       '@astrojs/starlight':
         specifier: 'catalog:'
-        version: 0.37.6(astro@5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))
+        version: 0.37.6(astro@5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))
       '@base-ui-components/react':
         specifier: 'catalog:'
         version: 1.0.0-rc.0(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -272,7 +272,7 @@ importers:
         version: link:../nanostores-qs
       astro:
         specifier: 'catalog:'
-        version: 5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
+        version: 5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
       decimal.js:
         specifier: 'catalog:'
         version: 10.6.0
@@ -389,8 +389,14 @@ packages:
   '@astrojs/internal-helpers@0.7.5':
     resolution: {integrity: sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==}
 
+  '@astrojs/internal-helpers@0.7.6':
+    resolution: {integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==}
+
   '@astrojs/markdown-remark@6.3.10':
     resolution: {integrity: sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==}
+
+  '@astrojs/markdown-remark@6.3.11':
+    resolution: {integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==}
 
   '@astrojs/mdx@4.3.13':
     resolution: {integrity: sha512-IHDHVKz0JfKBy3//52JSiyWv089b7GVSChIXLrlUOoTLWowG3wr2/8hkaEgEyd/vysvNQvGk+QhysXpJW5ve6Q==}
@@ -2287,8 +2293,8 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@5.17.1:
-    resolution: {integrity: sha512-oD3tlxTaVWGq/Wfbqk6gxzVRz98xa/rYlpe+gU2jXJMSD01k6sEDL01ZlT8mVSYB/rMgnvIOfiQQ3BbLdN237A==}
+  astro@5.18.1:
+    resolution: {integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -5758,6 +5764,8 @@ snapshots:
 
   '@astrojs/internal-helpers@0.7.5': {}
 
+  '@astrojs/internal-helpers@0.7.6': {}
+
   '@astrojs/markdown-remark@6.3.10':
     dependencies:
       '@astrojs/internal-helpers': 0.7.5
@@ -5784,12 +5792,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.13(astro@5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))':
+  '@astrojs/markdown-remark@6.3.11':
+    dependencies:
+      '@astrojs/internal-helpers': 0.7.6
+      '@astrojs/prism': 3.3.0
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      import-meta-resolve: 4.2.0
+      js-yaml: 4.1.1
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      shiki: 3.22.0
+      smol-toml: 1.6.0
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.0.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@astrojs/mdx@4.3.13(astro@5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
       '@mdx-js/mdx': 3.1.1
       acorn: 8.15.0
-      astro: 5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5836,17 +5870,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight@0.37.6(astro@5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))':
+  '@astrojs/starlight@0.37.6(astro@5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
-      '@astrojs/mdx': 4.3.13(astro@5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))
+      '@astrojs/mdx': 4.3.13(astro@5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))
       '@astrojs/sitemap': 3.7.0
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
-      astro-expressive-code: 0.41.6(astro@5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))
+      astro: 5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
+      astro-expressive-code: 0.41.6(astro@5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -7776,16 +7810,16 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.6(astro@5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)):
+  astro-expressive-code@0.41.6(astro@5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)):
     dependencies:
-      astro: 5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2)
       rehype-expressive-code: 0.41.6
 
-  astro@5.17.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2):
+  astro@5.18.1(@types/node@22.13.10)(jiti@2.4.2)(rollup@4.57.1)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.1
-      '@astrojs/internal-helpers': 0.7.5
-      '@astrojs/markdown-remark': 6.3.10
+      '@astrojs/internal-helpers': 0.7.6
+      '@astrojs/markdown-remark': 6.3.11
       '@astrojs/telemetry': 3.3.0
       '@capsizecss/unpack': 4.0.0
       '@oslojs/encoding': 1.1.0
@@ -7806,7 +7840,7 @@ snapshots:
       dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 1.7.0
-      esbuild: 0.25.12
+      esbuild: 0.27.3
       estree-walker: 3.0.3
       flattie: 1.1.1
       fontace: 0.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ catalog:
   "@typescript/native-preview": 7.0.0-dev.20260128.1
   "@vp-tw/eslint-config": ^1.0.5
   "@vp-tw/tsconfig": ^4.0.0
-  astro: ^5.17.1
+  astro: ^5.18.1
   commitizen: ^4.3.1
   cspell: ^9.6.2
   decimal.js: ^10.6.0


### PR DESCRIPTION
## Summary

- Bump `astro` catalog floor from `^5.17.1` to `^5.18.1`
- Minor: `actionBodySizeLimit` option, X-Forwarded-Proto fix, body size limit
- Replaces #28 (closed — contained vite 7→6 downgrade from stale base)

## Test plan

- [x] `pnpm run checkTypes` passes
- [x] `pnpm test` — 205 tests pass
- [x] `pnpm run lint` passes
- [x] `DOCS_BASE=/nanostores-qs/ pnpm --filter docs build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)