### PR TITLE
fix(docs): use relative links for base path compatibility

### DIFF
--- a/packages/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/packages/docs/src/content/docs/getting-started/quick-start.mdx
@@ -49,6 +49,6 @@ function Filters() {
 
 ## Next steps
 
-- Learn about [single parameter stores](/guides/single-param/)
-- Learn about [multi-parameter stores](/guides/multi-param/)
-- See all available [presets](/reference/presets-table/)
+- Learn about [single parameter stores](../../guides/single-param/)
+- Learn about [multi-parameter stores](../../guides/multi-param/)
+- See all available [presets](../../reference/presets-table/)

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Reactive, type-safe query string management built on nanostores
   actions:
     - text: Get Started
-      link: /getting-started/installation/
+      link: ./getting-started/installation/
       icon: right-arrow
     - text: View on GitHub
       link: https://github.com/VdustR/nanostores-qs

--- a/packages/docs/src/content/docs/reference/presets-table.mdx
+++ b/packages/docs/src/content/docs/reference/presets-table.mdx
@@ -214,4 +214,4 @@ Combines multiple preset configs into a single array parameter. No `optional`, `
 
 ## Creating custom presets
 
-Use `createPreset` to build your own preset function with the same options API. See [Custom Presets](/advanced/custom-presets/) for live examples with enum validation and decimal.js.
+Use `createPreset` to build your own preset function with the same options API. See [Custom Presets](../../advanced/custom-presets/) for live examples with enum validation and decimal.js.

--- a/packages/docs/src/content/docs/reference/utility-types.mdx
+++ b/packages/docs/src/content/docs/reference/utility-types.mdx
@@ -58,7 +58,7 @@ The `T extends infer U ? U : never` pattern forces TypeScript to resolve the typ
 
 ## `StoreConfig<T>`
 
-Type-safe config object for `createSearchParamStore`. See [Custom Presets](/advanced/custom-presets/#config-shape) for details.
+Type-safe config object for `createSearchParamStore`. See [Custom Presets](../../advanced/custom-presets/#config-shape) for details.
 
 ```ts
 import type { createQsUtils } from "@vp-tw/nanostores-qs";


### PR DESCRIPTION
## Summary

- Starlight doesn't prepend `base` to links in Markdown content or frontmatter
- All absolute paths (`/guides/single-param/`) resolved to root domain, missing `/nanostores-qs/` base → 404
- Convert 6 internal links across 4 files to relative paths

## Test plan

- [x] `DOCS_BASE=/nanostores-qs/ pnpm --filter docs build` — all hrefs have correct prefix
- [x] `grep` confirms zero absolute content links without base in built HTML
- [x] Types, tests, lint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)