### PR TITLE
build(deps): patch postcss-selector-parser vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,8 @@ catalogs:
 
 overrides:
   '@eslint-react/eslint-plugin': 2.10.1
+  eslint-plugin-vue>postcss-selector-parser: 7.1.3
+  postcss-nested>postcss-selector-parser: 6.1.3
 
 importers:
 
@@ -5032,12 +5034,12 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
 
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+  postcss-selector-parser@6.1.3:
+    resolution: {integrity: sha512-cDoO18VWCIWRsSaws3C23b0HXRxlUknttfdNcbXnf3IGHAPRNLlXPHc6dYiatOkxW0W4uZh524Plaaw5a7WEtQ==}
     engines: {node: '>=4'}
 
-  postcss-selector-parser@7.1.0:
-    resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
+  postcss-selector-parser@7.1.3:
+    resolution: {integrity: sha512-ajnd7iZnqjJDkyHNfznl/ZVO0lWqvBmQXfKKENx9/p/bEiF/L3eHwdydNUg9RXZx6xfZWOCmXmBa5oeB+YrAPQ==}
     engines: {node: '>=4'}
 
   postcss@8.5.16:
@@ -9685,7 +9687,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.4.2)
       natural-compare: 1.4.0
       nth-check: 2.1.1
-      postcss-selector-parser: 7.1.0
+      postcss-selector-parser: 7.1.3
       semver: 7.7.4
       vue-eslint-parser: 10.2.0(eslint@9.39.2(jiti@2.4.2))
       xml-name-validator: 4.0.0
@@ -11651,14 +11653,14 @@ snapshots:
   postcss-nested@6.2.0(postcss@8.5.16):
     dependencies:
       postcss: 8.5.16
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 6.1.3
 
-  postcss-selector-parser@6.1.2:
+  postcss-selector-parser@6.1.3:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-selector-parser@7.1.0:
+  postcss-selector-parser@7.1.3:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,8 @@ catalog:
   vitest: ^4.1.10
 overrides:
   "@eslint-react/eslint-plugin": $@eslint-react/eslint-plugin
+  eslint-plugin-vue>postcss-selector-parser: 7.1.3
+  postcss-nested>postcss-selector-parser: 6.1.3
 packages:
   - "packages/*"
 shellEmulator: true


### PR DESCRIPTION
## Summary

- pin `postcss-selector-parser` 6.x consumers to 6.1.3
- pin `postcss-selector-parser` 7.x consumers to 7.1.3
- resolve Dependabot alert 128 for GHSA-w9m9-85wc-3x92 without unrelated parent dependency upgrades

## Compatibility

- `postcss-nested@6.2.0` accepts `postcss-selector-parser@^6.1.1`
- `eslint-plugin-vue@10.7.0` accepts `postcss-selector-parser@^7.1.0`
- both patched releases retain the existing Node.js engine requirement

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint:cspell`
- `pnpm run lint:es:dry`
- `pnpm run lint:oxfmt:dry`
- `pnpm test` (205 tests)
- `pnpm run checkTypes`
- `pnpm run build`
- `pnpm audit --json` no longer reports `postcss-selector-parser`

## Security

Addresses [Dependabot alert 128](https://github.com/vp-tw/nanostores-qs/security/dependabot/128) / [GHSA-w9m9-85wc-3x92](https://github.com/advisories/GHSA-w9m9-85wc-3x92). Existing unrelated audit findings are outside this PR.